### PR TITLE
Added possibility to set extraData after plugin init

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ $("#drop-area-div").dmUploader(options);
 This way you can initialize the plugin. As parameter you can set all variables you want and the same goes for callbacks;
 down bellow you can see a list of what [options](#options) and [callbacks](#callbacks) are availabe.
 
+````javascript
+$("#drop-area-div").data('dmUploader').({ galleryID: 1 });
+````
+
+This way you can set extraData AFTER dmUploader has initialized. Its useful for dropdowns.
+
 ##Markup
 This is the simple html markup. The file input is optional but it provides an alternative way to select files for the user(check the online demo to se how to hide/style it)
 ````html

--- a/src/dmuploader.js
+++ b/src/dmuploader.js
@@ -275,6 +275,13 @@
     });
   }
 
+  DmUploader.prototype.setExtraData = function(options)
+  {
+    if( typeof options === 'undefined' ) return;
+
+    this.settings.extraData = options;
+  }
+
   $.fn.dmUploader = function(options){
     return this.each(function(){
       if(!$.data(this, pluginName)){


### PR DESCRIPTION
This is useful id we initialize uploader plugin and then on some custom select or input block got extraData parmeter so we can update it.

My scenario:

1) Page init
2) I choose gallery from select dropdown
3) Select onChange event updates upload plugin "extraData"
DONE
